### PR TITLE
Fix README instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 
+# jetbrains
+.idea
+
 # public/private keys
 /keys
 *.key.pem

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ To find the appKey go to the workspace app you created in Step 2 and copy it. It
 Run this command to create a `.env.local.` containing your app key. Replace `appKey_XXXX` with your appKey.
 
 ```
-touch env.local && echo -e "NEXT_PUBLIC_APP_KEY=appKey_XXXX" >> .env.local
+echo -e "NEXT_PUBLIC_APP_KEY=appKey_XXXX" >> .env.local
 ```
 
 <br />


### PR DESCRIPTION
As I tried out the commands noticed there was a typo (missing `.` in `touch env.local`). But we don't actually need to touch the file before writing out the environment variable (`>>` implicitly creates a file).